### PR TITLE
Use NOTICE instead of PRIVMSG to notify unidentified users

### DIFF
--- a/UnregNotify/plugin.py
+++ b/UnregNotify/plugin.py
@@ -76,7 +76,7 @@ class UnregNotify(callbacks.Plugin):
             return
 
         if account == '*':
-            irc.queueMsg(ircmsgs.privmsg(nick,
+            irc.queueMsg(ircmsgs.notice(nick,
                     'You joined {}, but you are not identified to services and cannot speak.'
                     ' For help with identification, type "/msg nickserv help register"'.format(channel)))
 


### PR DESCRIPTION
```the bot is still /msging me every time I connect, and that shows up as an unread notification.```